### PR TITLE
Added logic to check if corp or alliance exists

### DIFF
--- a/celerytask/tasks.py
+++ b/celerytask/tasks.py
@@ -369,17 +369,22 @@ def run_corp_update():
 
             # Update all allinace info's
             for all_alliance_info in EveManager.get_all_alliance_info():
-                all_alliance_api_info = EveApiManager.get_alliance_information(all_alliance_info.alliance_id)
-                if (not settings.IS_CORP and all_alliance_info.alliance_id == settings.ALLIANCE_ID):
-                    EveManager.update_alliance_info(all_alliance_api_info['id'], all_alliance_api_info['executor_id'],
-                                                    all_alliance_api_info['member_count'], False)
-                elif standing_level in corp_standings:
-                    if int(all_alliance_info.alliance_id) in corp_standings[standing_level]:
-                        if int(corp_standings[standing_level][int(all_alliance_info.alliance_id)][
-                            'standing']) >= settings.BLUE_STANDING:
-                            EveManager.update_alliance_info(all_alliance_api_info['id'],
-                                                            all_alliance_api_info['executor_id'],
-                                                            all_alliance_api_info['member_count'], True)
+                if EveApiManager.check_if_alliance_exists(all_alliance_info.alliance_id):
+                    all_alliance_api_info = EveApiManager.get_alliance_information(all_alliance_info.alliance_id)
+                    if (not settings.IS_CORP and all_alliance_info.alliance_id == settings.ALLIANCE_ID):
+                        EveManager.update_alliance_info(all_alliance_api_info['id'], all_alliance_api_info['executor_id'],
+                                                        all_alliance_api_info['member_count'], False)
+                    elif standing_level in corp_standings:
+                        if int(all_alliance_info.alliance_id) in corp_standings[standing_level]:
+                            if int(corp_standings[standing_level][int(all_alliance_info.alliance_id)][
+                                'standing']) >= settings.BLUE_STANDING:
+                                EveManager.update_alliance_info(all_alliance_api_info['id'],
+                                                                all_alliance_api_info['executor_id'],
+                                                                all_alliance_api_info['member_count'], True)
+                            else:
+                                EveManager.update_alliance_info(all_alliance_api_info['id'],
+                                                                all_alliance_api_info['executor_id'],
+                                                                all_alliance_api_info['member_count'], False)
                         else:
                             EveManager.update_alliance_info(all_alliance_api_info['id'],
                                                             all_alliance_api_info['executor_id'],
@@ -389,41 +394,44 @@ def run_corp_update():
                                                         all_alliance_api_info['executor_id'],
                                                         all_alliance_api_info['member_count'], False)
                 else:
-                    EveManager.update_alliance_info(all_alliance_api_info['id'],
-                                                    all_alliance_api_info['executor_id'],
-                                                    all_alliance_api_info['member_count'], False)
+                    #alliance no longer exists
+                    all_alliance_info.delete()
 
             # Update corp infos
             for all_corp_info in EveManager.get_all_corporation_info():
-                alliance = None
-                corpinfo = EveApiManager.get_corporation_information(all_corp_info.corporation_id)
-                if corpinfo['alliance']['id'] is not None:
-                    alliance = EveManager.get_alliance_info_by_id(corpinfo['alliance']['id'])
+                if EveApiManager.check_if_corp_exists(all_corp_info.corporation_id):
+                    alliance = None
+                    corpinfo = EveApiManager.get_corporation_information(all_corp_info.corporation_id)
+                    if corpinfo['alliance']['id'] is not None:
+                        alliance = EveManager.get_alliance_info_by_id(corpinfo['alliance']['id'])
 
-                if alliance is not None and all_corp_info.alliance is not None:
+                    if alliance is not None and all_corp_info.alliance is not None:
 
-                    if (not settings.IS_CORP) and (all_corp_info.alliance.alliance_id == settings.ALLIANCE_ID):
-                        EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], alliance, False)
-                    elif int(alliance.alliance_id) in corp_standings[standing_level]:
-                        if int(corp_standings[standing_level][int(alliance.alliance_id)][
-                            'standing']) >= settings.BLUE_STANDING:
-                            EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], alliance,
-                                                               True)
+                        if (not settings.IS_CORP) and (all_corp_info.alliance.alliance_id == settings.ALLIANCE_ID):
+                            EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], alliance, False)
+                        elif int(alliance.alliance_id) in corp_standings[standing_level]:
+                            if int(corp_standings[standing_level][int(alliance.alliance_id)][
+                                'standing']) >= settings.BLUE_STANDING:
+                                EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], alliance,
+                                                                   True)
+                            else:
+                                EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], alliance,
+                                                                   False)
                         else:
                             EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], alliance,
                                                                False)
                     else:
-                        EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], alliance,
-                                                           False)
-                else:
-                    if int(all_corp_info.corporation_id) in corp_standings[standing_level]:
-                        if int(corp_standings[standing_level][int(all_corp_info.corporation_id)][
-                            'standing']) >= settings.BLUE_STANDING:
-                            EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], None, True)
+                        if int(all_corp_info.corporation_id) in corp_standings[standing_level]:
+                            if int(corp_standings[standing_level][int(all_corp_info.corporation_id)][
+                                'standing']) >= settings.BLUE_STANDING:
+                                EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], None, True)
+                            else:
+                                EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], None, False)
                         else:
                             EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], None, False)
-                    else:
-                        EveManager.update_corporation_info(corpinfo['id'], corpinfo['members']['current'], None, False)
+                else:
+                    #corp has closed
+                    all_corp_info.delete()
 
         # Remove irrelevent corp and alliance models
         # Check the corps

--- a/services/managers/eve_api_manager.py
+++ b/services/managers/eve_api_manager.py
@@ -179,3 +179,38 @@ class EveApiManager():
             return False
 
         return False
+
+    @staticmethod
+    def check_if_alliance_exists(alliance_id):
+        try:
+            api = evelink.api.API()
+            eve = evelink.eve.EVE(api=api)
+            alliances = eve.alliances()
+            if int(alliance_id) in alliances[0]:
+                return True
+            else:
+                return False
+        except evelink.api.APIError as error:
+            print error
+            return False
+        except ValueError as error:
+            #attempts to catch error resulting from checking alliance_of nonetype models
+            print error
+            return False
+        return False
+
+    @staticmethod
+    def check_if_corp_exists(corp_id):
+        try:
+            api = evelink.api.API()
+            corp = evelink.corp.Corp(api=api)
+            corpinfo = corp.corporation_sheet(corp_id=corp_id)
+            if corpinfo[0]['members']['current'] > 0:
+                return True
+            else:
+                return False
+        except evelink.api.APIError as error:
+            #could be smart and check for error code523 to verify error due to no corp instead of catch-all
+            print error
+            return False
+        return False


### PR DESCRIPTION
Avoids attempting to retrieve corp or alliance info for corps or alliances which have closed and deletes the unnecessary models.

Addreses issues #93 and #68