### PR TITLE
Broadcast Plugin Support

### DIFF
--- a/alliance_auth/settings.py.example
+++ b/alliance_auth/settings.py.example
@@ -302,6 +302,7 @@ OPENFIRE_ADDRESS = os.environ.get('AA_OPENFIRE_ADDRESS', "http://yourdomain.com:
 OPENFIRE_SECRET_KEY = os.environ.get('AA_OPENFIRE_SECRET_KEY', "somekey")
 BROADCAST_USER = os.environ.get('AA_BROADCAST_USER', "broadcast@") + JABBER_URL
 BROADCAST_USER_PASSWORD = os.environ.get('AA_BROADCAST_USER_PASSWORD', "somepassword")
+BROADCAST_SERVICE_NAME = os.environ.get('AA_BROADCAST_SERVICE_NAME', "broadcast")
 
 ######################################
 # Mumble Configuration

--- a/services/managers/openfire_manager.py
+++ b/services/managers/openfire_manager.py
@@ -103,27 +103,33 @@ class OpenfireManager:
         client.connect(server=(settings.JABBER_SERVER, settings.JABBER_PORT))
         client.auth(settings.BROADCAST_USER, settings.BROADCAST_USER_PASSWORD, 'broadcast')
 
-        if group_name != 'all':
-            group = Group.objects.get(name=group_name)
-            for user in group.user_set.all():
-                auth_info = AuthServicesInfoManager.get_auth_service_info(user)
-                if auth_info:
-                    if auth_info.jabber_username != "":
-                        to_address = auth_info.jabber_username + '@' + settings.JABBER_URL
-                        message = xmpp.Message(to_address, broadcast_message)
-                        message.setAttr('type', 'chat')
-                        client.send(message)
-                        client.Process(1)
-        else:
-            for user in User.objects.all():
-                auth_info = AuthServicesInfoManager.get_auth_service_info(user)
-                if auth_info:
-                    if auth_info.jabber_username != "":
-                        to_address = auth_info.jabber_username + '@' + settings.JABBER_URL
-                        message = xmpp.Message(to_address, broadcast_message)
-                        message.setAttr('type', 'chat')
-                        client.send(message)
-                        client.Process(1)
+#        if group_name != 'all':
+#            group = Group.objects.get(name=group_name)
+#            for user in group.user_set.all():
+#                auth_info = AuthServicesInfoManager.get_auth_service_info(user)
+#                if auth_info:
+#                    if auth_info.jabber_username != "":
+#                        to_address = auth_info.jabber_username + '@' + settings.JABBER_URL
+#                        message = xmpp.Message(to_address, broadcast_message)
+#                        message.setAttr('type', 'chat')
+#                        client.send(message)
+#                        client.Process(1)
+#        else:
+#            for user in User.objects.all():
+#                auth_info = AuthServicesInfoManager.get_auth_service_info(user)
+#                if auth_info:
+#                    if auth_info.jabber_username != "":
+#                        to_address = auth_info.jabber_username + '@' + settings.JABBER_URL
+#                        message = xmpp.Message(to_address, broadcast_message)
+#                        message.setAttr('type', 'chat')
+#                        client.send(message)
+#                        client.Process(1)
+
+        to_address = group_name + '@' + settings.BROADCAST_SERVICE_NAME + '.' + settings.JABBER_URL
+        message = xmpp.Message(to_address, broadcast_message)
+        message.setAttr('type', 'chat')
+        client.send(message)
+        client.Process(1)
 
         client.disconnect()
 

--- a/services/managers/openfire_manager.py
+++ b/services/managers/openfire_manager.py
@@ -103,28 +103,6 @@ class OpenfireManager:
         client.connect(server=(settings.JABBER_SERVER, settings.JABBER_PORT))
         client.auth(settings.BROADCAST_USER, settings.BROADCAST_USER_PASSWORD, 'broadcast')
 
-#        if group_name != 'all':
-#            group = Group.objects.get(name=group_name)
-#            for user in group.user_set.all():
-#                auth_info = AuthServicesInfoManager.get_auth_service_info(user)
-#                if auth_info:
-#                    if auth_info.jabber_username != "":
-#                        to_address = auth_info.jabber_username + '@' + settings.JABBER_URL
-#                        message = xmpp.Message(to_address, broadcast_message)
-#                        message.setAttr('type', 'chat')
-#                        client.send(message)
-#                        client.Process(1)
-#        else:
-#            for user in User.objects.all():
-#                auth_info = AuthServicesInfoManager.get_auth_service_info(user)
-#                if auth_info:
-#                    if auth_info.jabber_username != "":
-#                        to_address = auth_info.jabber_username + '@' + settings.JABBER_URL
-#                        message = xmpp.Message(to_address, broadcast_message)
-#                        message.setAttr('type', 'chat')
-#                        client.send(message)
-#                        client.Process(1)
-
         to_address = group_name + '@' + settings.BROADCAST_SERVICE_NAME + '.' + settings.JABBER_URL
         message = xmpp.Message(to_address, broadcast_message)
         message.setAttr('type', 'chat')


### PR DESCRIPTION
Instead of looping through all users, offload the broadcast to Openfire via the broadcast plugin. 

Should greatly improve broadcast speeds.

Addresses #104 

This does however introduce some security issues: mainly that clever users would be able to figure out how to broadcast their own groups. As per the [plugin's readme](https://www.igniterealtime.org/projects/openfire/plugins/broadcast/readme.html), we could get users to set:

    plugin.broadcast.disableGroupPermissions    true
    plugin.broadcast.groupMembersAllowed        false
    plugin.broadcast.allowedUsers               broadcast@yourdomain.com

The broadcast user would need to be an administrator which raises its own security problems, but it's a step in the right direction.