### PR TITLE
Validate usernames during registration.

### DIFF
--- a/registration/forms.py
+++ b/registration/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib.auth.models import User
+import re
 
 
 class RegistrationForm(forms.Form):
@@ -11,7 +12,7 @@ class RegistrationForm(forms.Form):
 
     def clean(self):
         if ' ' in self.cleaned_data['username']:
-            raise forms.ValidationError(u'Username can not contain a space')
+            raise forms.ValidationError(u'Username cannot contain a space')
 
         # We attempt to get the user object if we succeed we know email as been used
         try:
@@ -19,6 +20,9 @@ class RegistrationForm(forms.Form):
             raise forms.ValidationError(u'Email as already been used')
         except:
             pass
+
+        if not re.match("^\w+$", self.cleaned_data['username']):
+            raise forms.ValidationError(u'Username contains illegal characters')
 
         if 'password' in self.cleaned_data and 'password_again' in self.cleaned_data:
             if self.cleaned_data['password'] != self.cleaned_data['password_again']:


### PR DESCRIPTION
Allows only letters, numbers and underscores.
Should prevent issue #46 from appearing on new installs.