### PR TITLE
Add timestamp to comments on HR applications, removed useless 'App ID…

### DIFF
--- a/hrapplications/models.py
+++ b/hrapplications/models.py
@@ -27,6 +27,7 @@ class HRApplication(models.Model):
 
 
 class HRApplicationComment(models.Model):
+    created_on = models.DateTimeField(auto_now_add=True)
     comment = models.CharField(max_length=254, default="")
     application = models.ForeignKey(HRApplication)
     commenter_user = models.ForeignKey(User)

--- a/hrapplications/models.py
+++ b/hrapplications/models.py
@@ -27,7 +27,7 @@ class HRApplication(models.Model):
 
 
 class HRApplicationComment(models.Model):
-    created_on = models.DateTimeField(auto_now_add=True)
+    created_on = models.DateTimeField(auto_now_add=True, null=True)
     comment = models.CharField(max_length=254, default="")
     application = models.ForeignKey(HRApplication)
     commenter_user = models.ForeignKey(User)

--- a/stock/templates/registered/hrapplicationmanagement.html
+++ b/stock/templates/registered/hrapplicationmanagement.html
@@ -21,9 +21,8 @@
                     </a>
                 </div>
             </h1>
-            <table class="table table-bordered">
+            <table class="table table-bordered table-condensed">
                 <tr>
-                    <th class="text-center">Application ID</th>
                     <th class="text-center">Username</th>
                     <th class="text-center">Main Character</th>
                     <th class="text-center">Corporation
@@ -32,7 +31,6 @@
                 </tr>
                 {% for personal_app in personal_apps %}
                     <tr>
-                        <td class="text-center">{{ personal_app.id }}</td>
                         <td class="text-center">{{ personal_app.user.username }}</td>
                         <td class="text-center">{{ personal_app.character_name }}</td>
                         <td class="text-center">{{ personal_app.corp.corporation_name }}</td>

--- a/stock/templates/registered/hrapplicationview.html
+++ b/stock/templates/registered/hrapplicationview.html
@@ -164,7 +164,7 @@
                                                 {% for comment in comments %}
                                                     <div class="panel panel-default">
                                                         <div class="panel-heading" role="tab" id="">
-                                                            <div class="panel-title">{{ comment.commenter_character.character_name }}
+                                                            <div class="panel-title">{{comment.commenter_character.created_on}} - {{ comment.commenter_character.character_name }}
                                                                 - {{ comment.commenter_character.corporation_name }}</div>
                                                         </div>
                                                         <div class="panel-body">{{ comment.comment }}</div>

--- a/stock/templates/registered/hrapplicationview.html
+++ b/stock/templates/registered/hrapplicationview.html
@@ -164,7 +164,7 @@
                                                 {% for comment in comments %}
                                                     <div class="panel panel-default">
                                                         <div class="panel-heading" role="tab" id="">
-                                                            <div class="panel-title">{{comment.commenter_character.created_on}} - {{ comment.commenter_character.character_name }}
+                                                            <div class="panel-title">{{comment.created_on}} - {{ comment.commenter_character.character_name }}
                                                                 - {{ comment.commenter_character.corporation_name }}</div>
                                                         </div>
                                                         <div class="panel-body">{{ comment.comment }}</div>


### PR DESCRIPTION
Add timestamp to comments on HR applications, remove useless 'Application ID' field from Application Overview and condensed table.