### PR TITLE
log api key invalidation at INFO level

### DIFF
--- a/services/managers/eve_api_manager.py
+++ b/services/managers/eve_api_manager.py
@@ -287,11 +287,11 @@ class EveApiManager():
     def validate_member_api(api_id, api_key):
         if settings.MEMBER_API_ACCOUNT:
             if EveApiManager.check_api_is_type_account(api_id, api_key) is not True:
-                logger.debug("Api id %s is not type account as required for members - failed validation." % api_id)
+                logger.info("Api id %s is not type account as required for members - failed validation." % api_id)
                 return False
         
         if EveApiManager.check_api_is_full(api_id, api_key) is not True:
-            logger.debug("Api id %s does not meet member access mask requirements - failed validation." % api_id)
+            logger.info("Api id %s does not meet member access mask requirements - failed validation." % api_id)
             return False
         return True
 
@@ -299,9 +299,9 @@ class EveApiManager():
     def validate_blue_api(api_id, api_key):
         if settings.BLUE_API_ACCOUNT:
             if EveApiManager.check_api_is_type_account(api_id, api_key) is not True:
-                logger.debug("Api id %s is not type account as required for blues - failed validation." % api_id)
+                logger.info("Api id %s is not type account as required for blues - failed validation." % api_id)
                 return False
         if EveApiManager.check_blue_api_is_full(api_id, api_key) is not True:
-            logger.debug("Api id %s does not meet minimum blue access mask requirements - failed validation." % api_id)
+            logger.info("Api id %s does not meet minimum blue access mask requirements - failed validation." % api_id)
             return False
         return True


### PR DESCRIPTION
Deletion of characters associated with an API key is logged at INFO.

However, the reason that an API key is marked invalid in the first place is only logged at DEBUG, so if you have debug logging disabled, you won't know why.