### PR TITLE
Eve avatar url as https

### DIFF
--- a/services/managers/phpbb3_manager.py
+++ b/services/managers/phpbb3_manager.py
@@ -47,7 +47,7 @@ class Phpbb3Manager:
     @staticmethod
     def __add_avatar(username, characterid):
         logger.debug("Adding EVE character id %s portrait as phpbb avater for user %s" % (characterid, username))
-        avatar_url = "http://image.eveonline.com/Character/" + characterid + "_64.jpg"
+        avatar_url = "https://image.eveonline.com/Character/" + characterid + "_64.jpg"
         cursor = connections['phpbb3'].cursor()
         userid = Phpbb3Manager.__get_user_id(username)
         cursor.execute(Phpbb3Manager.SQL_ADD_USER_AVATAR, [avatar_url, userid])


### PR DESCRIPTION
Eve avatar url should be https instead of http so you don't get a mixed content warning if you use https on your forum. The ultimate solution would be http/https agnostic with :// instead, but I don't know if that would work in this file.