### PR TITLE
Registered characters not found on EveWho will now be displayed.

### DIFF
--- a/corputils/views.py
+++ b/corputils/views.py
@@ -83,11 +83,14 @@ def corp_member_view(request, corpid = None):
                     mainname = mainchar.character_name
                     maincorp = mainchar.corporation_name
                     maincorpid = mainchar.corporation_id
-                except (ValueError, EveCharacter.DoesNotExist):
+                    api_pair = EveApiKeyPair.objects.get(api_id=char.api_id)
+                except (ValueError, EveCharacter.DoesNotExist, EveApiKeyPair.DoesNotExist):
+                    logger.info("No main character seem to be set for character %s" % char.character_name)
                     mainname = "User: " + char_owner.username
                     mainchar = char
                     maincorp = "Not set."
                     maincorpid = None
+                    api_pair = None
                 num_registered_characters = num_registered_characters + 1
                 characters_with_api.setdefault(mainname, Player(main=mainchar,
                                                                 maincorp=maincorp,
@@ -95,21 +98,48 @@ def corp_member_view(request, corpid = None):
                                                                 altlist=[],
                                                                 apilist=[])
                                                ).altlist.append(char)
-
-                characters_with_api[mainname].apilist.append(EveApiKeyPair.objects.get(api_id=char.api_id))
-            except(EveApiKeyPair.DoesNotExist):
-                logger.info("User %s EveApiKeyPair does not exist. is main char selected?" % char_owner)
-                pass
+                if api_pair:
+                    characters_with_api[mainname].apilist.append(api_pair)
 
             except (EveCharacter.DoesNotExist):
                 characters_without_api.update({member_data["name"]: member_data["id"]})
 
+        for char in EveCharacter.objects.filter(corporation_id=corpid):
+            if not char.character_id in member_list:
+                logger.info("Character %s does not exist in EveWho dump." % char.character_name)
+                char_owner = char.user
+                try:
+                    mainid = int(AuthServicesInfoManager.get_auth_service_info(user=char_owner).main_char_id)
+                    mainchar = EveCharacter.objects.get(character_id=mainid)
+                    mainname = mainchar.character_name
+                    maincorp = mainchar.corporation_name
+                    maincorpid = mainchar.corporation_id
+                    api_pair = EveApiKeyPair.objects.get(api_id=char.api_id)
+                except (ValueError, EveCharacter.DoesNotExist, EveApiKeyPair.DoesNotExist):
+                    logger.info("No main character seem to be set for character %s" % char.character_name)
+                    mainname = "User: " + char_owner.username
+                    mainchar = char
+                    maincorp = "Not set."
+                    maincorpid = None
+                    api_pair = None
+                num_registered_characters = num_registered_characters + 1
+                characters_with_api.setdefault(mainname, Player(main=mainchar,
+                                                                maincorp=maincorp,
+                                                                maincorpid=maincorpid,
+                                                                altlist=[],
+                                                                apilist=[])
+                                               ).altlist.append(char)
+                if api_pair:
+                    characters_with_api[mainname].apilist.append(api_pair)
+
+        n_unacounted = corp.member_count - (num_registered_characters + len(characters_without_api))
 
         if not settings.IS_CORP:
             context = {"membercorp_list": membercorp_list,
                        "corp": corp,
                        "characters_with_api": sorted(characters_with_api.items()),
                        'n_registered': num_registered_characters,
+                       'n_unacounted': n_unacounted,
                        "characters_without_api": sorted(characters_without_api.items()),
                        "search_form": CorputilsSearchForm()}
         else:
@@ -117,6 +147,7 @@ def corp_member_view(request, corpid = None):
             context = {"corp": corp,
                        "characters_with_api": sorted(characters_with_api.items()),
                        'n_registered': num_registered_characters,
+                       'n_unacounted': n_unacounted,
                        "characters_without_api": sorted(characters_without_api.items()),
                        "search_form": CorputilsSearchForm()}
 

--- a/stock/templates/registered/corputils.html
+++ b/stock/templates/registered/corputils.html
@@ -28,7 +28,7 @@
 
                                          <p>Player count: {{characters_with_api|length}}</p>
 
-                                         <p>Unregistered characters: {{characters_without_api|length}}</p>
+                                         <p>Unregistered characters: {{characters_without_api|length|add:n_unacounted}}</p>
                                     </div>
                                     <div class="col-lg-12 col-sm-5">
                                         <b>API Index:</b>
@@ -76,7 +76,7 @@
                         </nav>
                         <ul class="nav nav-tabs">
                             <li class="active"><a data-toggle="tab" href="#gotapi">Registered Main Characters <b>({{characters_with_api|length}})</b></a></li>
-                            <li><a data-toggle="tab" href="#noapi">Characters without API <b>({{characters_without_api|length}})</b></a></li>
+                            <li><a data-toggle="tab" href="#noapi">Characters without API <b>({{characters_without_api|length|add:n_unacounted}})</b></a></li>
                         </ul>
                     <div class="tab-content">
                         <div id="gotapi" class="tab-pane fade in active">
@@ -146,7 +146,12 @@
                         <div id="noapi" class="tab-pane fade">
                         {% if characters_without_api %}
                             <div class="panel-body">
-                                <div class="table-responsive">    
+                                <div class="table-responsive">
+                                    {% if 0 < n_unacounted %}
+                                    <div class="alert alert-danger" role="alert">
+                                            <h3>There are atleast {{ n_unacounted }} characters not accounted for in EveWho.</h3>
+                                    </div>
+                                    {% endif %}
                                     <table class="table table-condensed table-hover table-striped">
                                         <tr>
                                             <th class="col-md-1"></th>


### PR DESCRIPTION
The unregistered characters count is also corrected and a note added when there is a discrepancy between the number of people in corp and the number in EveWho. This adresses #338.

But don't merge yet. This needs to be tested on a server with more users and registered characters than my 5 or so, for performance. Also it needs to be tested with someone who actually experiences the problem with missing characters. Have no such APIs at hand.