### PR TITLE
Automatic rejection of old API IDs

### DIFF
--- a/alliance_auth/settings.py.example
+++ b/alliance_auth/settings.py.example
@@ -335,11 +335,15 @@ ALLIANCE_NAME = os.environ.get('AA_ALLIANCE_NAME', '')
 # MEMBER_API_ACCOUNT - Require API to be for Account and not character restricted
 # BLUE_API_MASK - Numeric value of minimum API mask required for blues
 # BLUE_API_ACCOUNT - Require API to be for Account and not character restricted
+# REJECT_OLD_APIS - Require each submitted API be newer than the latest submitted API
+# REJECT_OLD_APIS_MARGIN - Margin from latest submitted API ID within which a newly submitted API is still accepted
 #######################
 MEMBER_API_MASK = os.environ.get('AA_MEMBER_API_MASK', 268435455)
 MEMBER_API_ACCOUNT = 'True' == os.environ.get('AA_MEMBER_API_ACCOUNT', 'True')
 BLUE_API_MASK = os.environ.get('AA_BLUE_API_MASK', 8388608)
 BLUE_API_ACCOUNT = 'True' == os.environ.get('AA_BLUE_API_ACCOUNT', 'False')
+REJECT_OLD_APIS = 'True' == os.environ.get('AA_REJECT_OLD_APIS', 'False')
+REJECT_OLD_APIS_MARGIN = os.environ.get('AA_REJECT_OLD_APIS_MARGIN', 50)
 
 ##########################
 # Pathfinder Configuration

--- a/eveonline/forms.py
+++ b/eveonline/forms.py
@@ -35,6 +35,8 @@ class UpdateKeyForm(forms.Form):
                     raise forms.ValidationError(u'API key already exist')
                 if EveApiManager.api_key_is_valid(self.cleaned_data['api_id'], self.cleaned_data['api_key']) is False:
                     raise forms.ValidationError(u'API key is invalid')
+                if EveManager.check_if_api_key_pair_is_new(self.cleaned_data['api_id']) is False:
+                    raise forms.ValidationError(u'API key is too old')
                 chars = EveApiManager.get_characters_from_api(self.cleaned_data['api_id'], self.cleaned_data['api_key']).result
                 states = []
                 states.append(self.user_state)

--- a/eveonline/forms.py
+++ b/eveonline/forms.py
@@ -37,7 +37,7 @@ class UpdateKeyForm(forms.Form):
                     raise forms.ValidationError(u'API key is invalid')
                 if (settings.REJECT_OLD_APIS and
                     EveManager.check_if_api_key_pair_is_new(self.cleaned_data['api_id'], settings.REJECT_OLD_APIS_MARGIN) is False):
-                    raise forms.ValidationError(u'API key is too old')
+                    raise forms.ValidationError(u'API key is too old. Please create a new key')
                 chars = EveApiManager.get_characters_from_api(self.cleaned_data['api_id'], self.cleaned_data['api_key']).result
                 states = []
                 states.append(self.user_state)

--- a/eveonline/forms.py
+++ b/eveonline/forms.py
@@ -35,7 +35,8 @@ class UpdateKeyForm(forms.Form):
                     raise forms.ValidationError(u'API key already exist')
                 if EveApiManager.api_key_is_valid(self.cleaned_data['api_id'], self.cleaned_data['api_key']) is False:
                     raise forms.ValidationError(u'API key is invalid')
-                if EveManager.check_if_api_key_pair_is_new(self.cleaned_data['api_id']) is False:
+                if (settings.REJECT_OLD_APIS and
+                    EveManager.check_if_api_key_pair_is_new(self.cleaned_data['api_id'], settings.REJECT_OLD_APIS_MARGIN) is False):
                     raise forms.ValidationError(u'API key is too old')
                 chars = EveApiManager.get_characters_from_api(self.cleaned_data['api_id'], self.cleaned_data['api_key']).result
                 states = []

--- a/eveonline/managers.py
+++ b/eveonline/managers.py
@@ -158,6 +158,18 @@ class EveManager:
             return False
 
     @staticmethod
+    def check_if_api_key_pair_is_new(api_id):
+        if EveApiKeyPair.objects.count() == 0:
+            return True
+        latest_api_id = int(EveApiKeyPair.objects.order_by('-api_id')[0].api_id)
+        if latest_api_id >= api_id:
+            logger.debug("api key (%d) is older than latest API key (%d). Rejecting" % (api_id, latest_api_id) )
+            return False
+        else:
+            logger.debug("api key (%d) is new. Accepting" % api_id )
+            return True
+
+    @staticmethod
     def delete_api_key_pair(api_id, user_id):
         logger.debug("Deleting api id %s" % api_id)
         if EveApiKeyPair.objects.filter(api_id=api_id).exists():

--- a/eveonline/managers.py
+++ b/eveonline/managers.py
@@ -158,10 +158,9 @@ class EveManager:
             return False
 
     @staticmethod
-    def check_if_api_key_pair_is_new(api_id):
+    def check_if_api_key_pair_is_new(api_id, fudge_factor):
         if EveApiKeyPair.objects.count() == 0:
             return True
-        fudge_factor  = 50; # Fudge factor of API IDs for two people creating APIs simultaneously
         latest_api_id = int(EveApiKeyPair.objects.order_by('-api_id')[0].api_id) - fudge_factor
         if latest_api_id >= api_id:
             logger.debug("api key (%d) is older than latest API key (%d). Rejecting" % (api_id, latest_api_id) )

--- a/eveonline/managers.py
+++ b/eveonline/managers.py
@@ -161,7 +161,8 @@ class EveManager:
     def check_if_api_key_pair_is_new(api_id):
         if EveApiKeyPair.objects.count() == 0:
             return True
-        latest_api_id = int(EveApiKeyPair.objects.order_by('-api_id')[0].api_id)
+        fudge_factor  = 50; # Fudge factor of API IDs for two people creating APIs simultaneously
+        latest_api_id = int(EveApiKeyPair.objects.order_by('-api_id')[0].api_id) - fudge_factor
         if latest_api_id >= api_id:
             logger.debug("api key (%d) is older than latest API key (%d). Rejecting" % (api_id, latest_api_id) )
             return False


### PR DESCRIPTION
Added automatic rejection of old APIs based on newest API ID on record, per issue #436 