### PR TITLE
404 error when selecting doctrin/fitting

### DIFF
--- a/stock/templates/registered/fleetup.html
+++ b/stock/templates/registered/fleetup.html
@@ -82,7 +82,7 @@
                                         {% if start.doctrine %}
                                         {% for doctrine in start.doctrine %}
                                             
-                                            <a href="/fleetup/doctrines/{{ doctrine.Id }}" class="label label-success">{{ doctrine.Name }}</a>
+                                            <a href="/fleetup/doctrines/{{ doctrine.Id }}/" class="label label-success">{{ doctrine.Name }}</a>
                                             
                                         {% endfor %}
                                             

--- a/stock/templates/registered/fleetupdoctrine.html
+++ b/stock/templates/registered/fleetupdoctrine.html
@@ -56,7 +56,7 @@
                                 {% for item in Role.list %}
                                 <tr>
                                     <td>
-                                       <a href="/fleetup/fittings/{{ item.FittingId }}"><img src="https://image.eveonline.com/InventoryType/{{ item.EveTypeId }}_32.png"></a>
+                                       <a href="/fleetup/fittings/{{ item.FittingId }}/"><img src="https://image.eveonline.com/InventoryType/{{ item.EveTypeId }}_32.png"></a>
                                     </td>
                                     <td>
                                         {{ item.Name }}

--- a/stock/templates/registered/fleetupfittingsview.html
+++ b/stock/templates/registered/fleetupfittingsview.html
@@ -47,7 +47,7 @@
             
             <tr>
                 <td>
-                    <a href="/fleetup/fittings/{{ fittings.fitting_id }}"><img src="https://image.eveonline.com/InventoryType/{{ fittings.icon_id }}_32.png"></a>
+                    <a href="/fleetup/fittings/{{ fittings.fitting_id }}/"><img src="https://image.eveonline.com/InventoryType/{{ fittings.icon_id }}_32.png"></a>
                 </td> 
                 <td>
                     {{ fittings.name }}


### PR DESCRIPTION
This fix will resolve the 404 (Page not found) error due to a missing "/" in the URL from different links.

fleetup.html row 85
fleetupdoctrin.html row 59
fleetupfittingsview.html row 50