### PR TITLE
Fix users cannot delete mumble account

### DIFF
--- a/services/managers/mumble_manager.py
+++ b/services/managers/mumble_manager.py
@@ -115,3 +115,7 @@ class MumbleManager:
             model.save()
         else:
             logger.error("User %s not found on mumble. Unable to update groups." % username)
+
+    @staticmethod
+    def user_exists(username):
+        return MumbleUser.objects.filter(username=username).exists()

--- a/services/views.py
+++ b/services/views.py
@@ -514,9 +514,8 @@ def activate_mumble(request):
 def deactivate_mumble(request):
     logger.debug("deactivate_mumble called by user %s" % request.user)
     authinfo = AuthServicesInfo.objects.get_or_create(user=request.user)[0]
-    result = MumbleManager.delete_user(authinfo.mumble_username)
-    # if false we failed
-    if result:
+    # if we successfully remove the user or the user is already removed
+    if MumbleManager.delete_user(authinfo.mumble_username) or not MumbleManager.user_exists(authinfo.mumble_username):
         AuthServicesInfoManager.update_user_mumble_info("", request.user)
         logger.info("Successfully deactivated mumble for user %s" % request.user)
         messages.success(request, 'Deactivated Mumble account.')


### PR DESCRIPTION
Under certain circumstances (partial backup restore, table truncate, external management) the AuthServicesInfo and MumbleUser models can become unsynced, preventing a user from deleting or refreshing their Mumble account. This requires services admin to manually remove their mumble username in AuthServicesInfo which will then allow the user to create a new mumble account.

This PR adds a check for already deleted MumbleUser entities if the attempt to delete the users mumble account fails.